### PR TITLE
Add provision to skip if the session fails during collection

### DIFF
--- a/pytest_test_groups/__init__.py
+++ b/pytest_test_groups/__init__.py
@@ -28,7 +28,9 @@ def pytest_collection_modifyitems(session, config, items):
     group_id = config.getoption('test-group')
 
     # Give up if the session fails during collection
-    if session.shouldstop or session.testsfailed:
+    shouldstop = getattr(session, 'shouldstop', None)
+    testsfailed = getattr(session, 'testsfailed', None)
+    if shouldstop or testsfailed:
         return
 
     if not group_count or not group_id:

--- a/pytest_test_groups/__init__.py
+++ b/pytest_test_groups/__init__.py
@@ -27,6 +27,10 @@ def pytest_collection_modifyitems(session, config, items):
     group_count = config.getoption('test-group-count')
     group_id = config.getoption('test-group')
 
+    # Give up if the session fails during collection
+    if session.shouldstop or session.testsfailed:
+        return
+
     if not group_count or not group_id:
         return
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author='Mark Adams',
     author_email='mark@markadams.me',
     packages=['pytest_test_groups'],
-    version='0.9',
+    version='0.10',
     long_description=read('README.rst'),
     install_requires=['pytest>=2.5'],
     classifiers=['Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Without this change if pytest fails during collection the errors from that previous failure are swallowed and the plugin fails due to having an invalid number of tests/groups.