### PR TITLE
Add option to execute tests in psuedo-random order

### DIFF
--- a/pytest_test_groups/__init__.py
+++ b/pytest_test_groups/__init__.py
@@ -1,3 +1,4 @@
+import random
 import math
 
 
@@ -21,14 +22,20 @@ def pytest_addoption(parser):
                     help='The number of groups to split the tests into')
     group.addoption('--test-group', dest='test-group', type=int,
                     help='The group of tests that should be executed')
+    group.addoption('--test-group-random-seed', dest='random-seed', type=float,
+                    help='Value between 0.0 and 0.9 to seed psuedo-random test ordering')
 
 
 def pytest_collection_modifyitems(session, config, items):
     group_count = config.getoption('test-group-count')
     group_id = config.getoption('test-group')
+    seed = config.getoption('random-seed', False)
 
     if not group_count or not group_id:
         return
+
+    if seed:
+        random.shuffle(items, lambda: seed)
 
     total_items = len(items)
 

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -19,3 +19,55 @@ def test_group_runs_appropriate_tests(testdir):
     result.stdout.fnmatch_lines([
         'Running test group #2 (1 tests)'
     ])
+
+
+def test_group_runs_all_test(testdir):
+    """Given a large set of tests executed in random order, assert that all
+    tests are executed.
+    """
+    testdir.makepyfile("""
+        def test_b(): pass
+        def test_c(): pass
+        def test_d(): pass
+        def test_e(): pass
+        def test_f(): pass
+        def test_g(): pass
+        def test_h(): pass
+        def test_i(): pass
+        def test_j(): pass
+        def test_k(): pass
+        def test_l(): pass
+        def test_m(): pass
+        def test_n(): pass
+        def test_o(): pass
+        def test_p(): pass
+        def test_q(): pass
+        def test_r(): pass
+        def test_s(): pass
+        def test_t(): pass
+        def test_u(): pass
+        def test_v(): pass
+        def test_w(): pass
+        def test_x(): pass
+        def test_y(): pass
+        def test_z(): pass
+    """)
+
+    result = testdir.inline_run('--test-group-count', '2',
+                                '--test-group', '1',
+                                '--test-group-random-seed', '0.5')
+    group_1 = [x.item.name for x in result.calls if x._name == 'pytest_runtest_call']
+    result.assertoutcome(passed=13)
+
+    result = testdir.inline_run('--test-group-count', '2',
+                                '--test-group', '2',
+                                '--test-group-random-seed', '0.5')
+    group_2 = [x.item.name for x in result.calls if x._name == 'pytest_runtest_call']
+    result.assertoutcome(passed=12)
+
+    result = testdir.inline_run('--test-group-count', '1',
+                                '--test-group', '1',
+                                '--test-group-random-seed', '0.5')
+    all_tests = [x.item.name for x in result.calls if x._name == 'pytest_runtest_call']
+
+    assert set(group_1 + group_2) == set(all_tests)


### PR DESCRIPTION
As the title says, provides a new switch that will allow the test groups to be executed in a psuedo-random order.