### PR TITLE
Drop support for 2.6 and 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: python
 sudo: false
 python:
-  - "2.6"
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{26,27,33,34,35}, flake8
+envlist = py{27,33,34,35}, flake8
 
 [testenv]
 commands =


### PR DESCRIPTION
Newer versions of Flake8 do not support these versions of python. Drop support.