### PR TITLE
Random Fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Usage
     py.test --test-group-count 10 --test-group=2
     
     # Randomize the test order, split into 10 groups, and run the second group
-    py.test --test-group-count 10 --test-group=2 --test-group-random-seed=0.618033
+    py.test --test-group-count 10 --test-group=2 --test-group-random-seed=12345
 
 
 Why would I use this?

--- a/pytest_test_groups/__init__.py
+++ b/pytest_test_groups/__init__.py
@@ -22,8 +22,8 @@ def pytest_addoption(parser):
                     help='The number of groups to split the tests into')
     group.addoption('--test-group', dest='test-group', type=int,
                     help='The group of tests that should be executed')
-    group.addoption('--test-group-random-seed', dest='random-seed', type=float,
-                    help='Value between 0.0 and 1.0 to seed psuedo-random test ordering')
+    group.addoption('--test-group-random-seed', dest='random-seed', type=int,
+                    help='Integer to seed psuedo-random test ordering')
 
 
 def pytest_collection_modifyitems(session, config, items):

--- a/pytest_test_groups/__init__.py
+++ b/pytest_test_groups/__init__.py
@@ -1,4 +1,4 @@
-import random
+from random import Random
 import math
 
 
@@ -35,7 +35,8 @@ def pytest_collection_modifyitems(session, config, items):
         return
 
     if seed:
-        random.shuffle(items, lambda: seed)
+        seeded = Random(seed)
+        seeded.shuffle(items)
 
     total_items = len(items)
 

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -55,19 +55,19 @@ def test_group_runs_all_test(testdir):
 
     result = testdir.inline_run('--test-group-count', '2',
                                 '--test-group', '1',
-                                '--test-group-random-seed', '0.5')
+                                '--test-group-random-seed', '5')
     group_1 = [x.item.name for x in result.calls if x._name == 'pytest_runtest_call']
     result.assertoutcome(passed=13)
 
     result = testdir.inline_run('--test-group-count', '2',
                                 '--test-group', '2',
-                                '--test-group-random-seed', '0.5')
+                                '--test-group-random-seed', '5')
     group_2 = [x.item.name for x in result.calls if x._name == 'pytest_runtest_call']
     result.assertoutcome(passed=12)
 
     result = testdir.inline_run('--test-group-count', '1',
                                 '--test-group', '1',
-                                '--test-group-random-seed', '0.5')
+                                '--test-group-random-seed', '5')
     all_tests = [x.item.name for x in result.calls if x._name == 'pytest_runtest_call']
 
     assert set(group_1 + group_2) == set(all_tests)


### PR DESCRIPTION
- Use integer for random seed instead of float

    Floating point numbers are subject to too many platform-level problems
    to reliably seed random number generators, so switch to using integers.

- Use Random() to generate seeded numbers

    The proper way to create random numbers from a seed in Python is to
    instantiate a `Random()` object with the desired seed, which properly
    decouples the new PRNG from any calls to `random.random()`.

    Also: replacing calls to `random()` with a constant function is a bad
    habit to get into.

@mark-adams @systemsoverload