### PR TITLE
Run tests in original order even when selected randomly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Usage
     # Split the tests into 10 groups and run the second group
     py.test --test-group-count 10 --test-group=2
     
-    # Randomize the test order, split into 10 groups, and run the second group
+    # Assign tests pseudo-randomly into 10 groups, and run the second group
     py.test --test-group-count 10 --test-group=2 --test-group-random-seed=12345
 
 

--- a/pytest_test_groups/__init__.py
+++ b/pytest_test_groups/__init__.py
@@ -23,7 +23,7 @@ def pytest_addoption(parser):
     group.addoption('--test-group', dest='test-group', type=int,
                     help='The group of tests that should be executed')
     group.addoption('--test-group-random-seed', dest='random-seed', type=int,
-                    help='Integer to seed pseudo-random test ordering')
+                    help='Integer to seed pseudo-random test selection')
 
 
 def pytest_collection_modifyitems(session, config, items):
@@ -34,11 +34,16 @@ def pytest_collection_modifyitems(session, config, items):
     if not group_count or not group_id:
         return
 
-    if seed:
+    if seed is not False:
+        original_order = {item: index for index, item in enumerate(items)}
         seeded = Random(seed)
         seeded.shuffle(items)
 
     items[:] = get_group(items, group_count, group_id)
+
+    if seed is not False:
+        # Revert the shuffled sample of tests back to their original order.
+        items.sort(key=original_order.__getitem__)
 
     terminal_reporter = config.pluginmanager.get_plugin('terminalreporter')
     terminal_writer = create_terminal_writer(config)

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -22,8 +22,8 @@ def test_group_runs_appropriate_tests(testdir):
 
 
 def test_group_runs_all_test(testdir):
-    """Given a large set of tests executed in random order, assert that all
-    tests are executed.
+    """Given a large set of tests executed with a random seed, assert that all
+    tests are executed exactly once.
     """
     testdir.makepyfile("""
         def test_b(): pass
@@ -71,3 +71,23 @@ def test_group_runs_all_test(testdir):
     all_tests = [x.item.name for x in result.calls if x._name == 'pytest_runtest_call']
 
     assert set(group_1 + group_2) == set(all_tests)
+
+
+def test_random_group_runs_in_original_order(testdir):
+    """When running tests with a random seed, check test order is unchanged"""
+    testdir.makepyfile("""
+        def test_b(): pass
+        def test_c(): pass
+        def test_d(): pass
+        def test_e(): pass
+        def test_f(): pass
+        def test_g(): pass
+        def test_h(): pass
+        def test_i(): pass
+    """)
+
+    result = testdir.inline_run('--test-group-count', '2',
+                                '--test-group', '1',
+                                '--test-group-random-seed', '5')
+    group_1 = [x.item.name for x in result.calls if x._name == 'pytest_runtest_call']
+    assert group_1 == sorted(group_1)

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -76,18 +76,18 @@ def test_group_runs_all_test(testdir):
 def test_random_group_runs_in_original_order(testdir):
     """When running tests with a random seed, check test order is unchanged"""
     testdir.makepyfile("""
-        def test_b(): pass
-        def test_c(): pass
-        def test_d(): pass
-        def test_e(): pass
-        def test_f(): pass
-        def test_g(): pass
-        def test_h(): pass
         def test_i(): pass
+        def test_h(): pass
+        def test_g(): pass
+        def test_f(): pass
+        def test_e(): pass
+        def test_d(): pass
+        def test_c(): pass
+        def test_b(): pass
     """)
 
     result = testdir.inline_run('--test-group-count', '2',
                                 '--test-group', '1',
                                 '--test-group-random-seed', '5')
     group_1 = [x.item.name for x in result.calls if x._name == 'pytest_runtest_call']
-    assert group_1 == sorted(group_1)
+    assert group_1 == sorted(group_1, reverse=True)


### PR DESCRIPTION
`--test-group-random-seed` originally made tests run in
a hard to predict order. For many codebases that's okay,
but this is an unnecessary limitation which can cause non-determinism
in test suites that aren't well-behaved.

This changes the `--test-group-random-seed` option to preserve
the original ordering of the tests within each group.