### PR TITLE
Simplify code for test selection, update tests, update supported python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.7"
   - "3.8"
 install:
-  - "pip install -U flake8 pytest black"
+  - "pip install -U flake8 pytest"
   - "pip install -e ."
 before_script:
   - "flake8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,13 @@ language: python
 sudo: false
 python:
   - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
+  - "3.7"
+  - "3.8"
 install:
-  - "pip install -U flake8 pytest"
+  - "pip install -U flake8 pytest black"
   - "pip install -e ."
 before_script:
   - "flake8"
+  - "black"
 script:
   - py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,5 @@ install:
   - "pip install -e ."
 before_script:
   - "flake8"
-  - "black"
 script:
   - py.test

--- a/pytest_test_groups/__init__.py
+++ b/pytest_test_groups/__init__.py
@@ -1,27 +1,19 @@
 # -*- coding: utf-8 -*-
 
 # Import python libs
-import math
 from random import Random
 
 # Import 3rd-party libs
 from _pytest.config import create_terminal_writer
 
 
-def get_group_size(total_items, total_groups):
-    """Return the group size."""
-    return int(math.ceil(float(total_items) / total_groups))
-
-
-def get_group(items, group_size, group_id):
-    """Get the items from the passed in group based on group size."""
-    start = group_size * (group_id - 1)
-    end = start + group_size
-
-    if start >= len(items) or start < 0:
+def get_group(items, group_count, group_id):
+    """Get the items from the passed in group based on group count."""
+    if not (1 <= group_id <= group_count):
         raise ValueError("Invalid test-group argument")
 
-    return items[start:end]
+    start = group_id - 1
+    return items[start:len(items):group_count]
 
 
 def pytest_addoption(parser):
@@ -46,11 +38,7 @@ def pytest_collection_modifyitems(session, config, items):
         seeded = Random(seed)
         seeded.shuffle(items)
 
-    total_items = len(items)
-
-    group_size = get_group_size(total_items, group_count)
-    tests_in_group = get_group(items, group_size, group_id)
-    items[:] = tests_in_group
+    items[:] = get_group(items, group_count, group_id)
 
     terminal_reporter = config.pluginmanager.get_plugin('terminalreporter')
     terminal_writer = create_terminal_writer(config)

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,8 @@ setup(
                  'Programming Language :: Python',
                  'Topic :: Software Development :: Testing',
                  'Programming Language :: Python :: 2.7',
-                 'Programming Language :: Python :: 3.3',
-                 'Programming Language :: Python :: 3.4',
-                 'Programming Language :: Python :: 3.5'
+                 'Programming Language :: Python :: 3.7',
+                 'Programming Language :: Python :: 3.8',
                  ],
     entry_points={
         'pytest11': [

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -1,50 +1,37 @@
+from itertools import chain
+
 import pytest
 
-from pytest_test_groups import get_group, get_group_size
-
-
-def test_group_size_computed_correctly_for_even_group():
-    expected = 8
-    actual = get_group_size(32, 4)  # 32 total tests; 4 groups
-
-    assert expected == actual
-
-
-def test_group_size_computed_correctly_for_odd_group():
-    expected = 8
-    actual = get_group_size(31, 4)  # 31 total tests; 4 groups
-
-    assert expected == actual
+from pytest_test_groups import get_group
 
 
 def test_group_is_the_proper_size():
     items = [str(i) for i in range(32)]
     group = get_group(items, 8, 1)
 
-    assert len(group) == 8
+    assert len(group) == 4
 
 
 def test_all_groups_together_form_original_set_of_tests():
-    items = [str(i) for i in range(32)]
-
-    groups = [get_group(items, 8, i) for i in range(1, 5)]
-
-    combined = []
-    for group in groups:
-        combined.extend(group)
-
-    assert combined == items
+    group_count = 8
+    for item_size in range(group_count, 32):
+        items = [str(i) for i in range(item_size)]
+        groups = [get_group(items, group_count, i) for i in range(1, group_count + 1)]
+        combined = set(chain.from_iterable(groups))
+        assert combined == set(items)
 
 
 def test_group_that_is_too_high_raises_value_error():
     items = [str(i) for i in range(32)]
 
     with pytest.raises(ValueError):
-        get_group(items, 8, 5)
+        # When group_count=4, group_id=5 is out of bounds
+        get_group(items, 4, 5)
 
 
 def test_group_that_is_too_low_raises_value_error():
     items = [str(i) for i in range(32)]
 
     with pytest.raises(ValueError):
-        get_group(items, 8, 0)
+        # When group_count=4, group_id=0 is out of bounds
+        get_group(items, 4, 0)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,33,34,35}, flake8
+envlist = py{27,37,38}, flake8
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,37,38}, flake8, black
+envlist = py{27,37,38}, flake8
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,37,38}, flake8
+envlist = py{27,37,38}, flake8, black
 
 [testenv]
 commands =


### PR DESCRIPTION
Using the slice-operator with `step` parameter greatly simplifies logic for selecting tests while also ensuring optimally balanced group lengths.

Eliminated `get_group_size` as unnecessary.

Updated tests to reflect changes.
 
Dropped python3.3, python3.4, and python3.5 in favor of python3.7 and python3.8.

~~Added python-black to test formatting.~~