### PR TITLE
Grouping tests by files instead of items

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,10 @@ Usage
     # Randomize the test order, split into 10 groups, and run the second group
     py.test --test-group-count 10 --test-group=2 --test-group-random-seed=12345
 
+    # Split the tests by files instead of items into 3 groups and run the second group.
+    # The groups might not be in the same size as each group contains full test files
+    py.test --test-group-count 10 --test-group=2 --test-group-by-files
+
 
 Why would I use this?
 ------------------------------------------------------------------

--- a/pytest_test_groups/__init__.py
+++ b/pytest_test_groups/__init__.py
@@ -23,7 +23,7 @@ def get_file_group(items, group_count, group_id):
     for item in items:
         items_in_module[item.module] += 1
 
-    max_items_per_group = ceil(len(items) / group_count)
+    max_items_per_group = ceil(len(items) / float(group_count))
 
     modules = sorted(
         items_in_module.keys(),

--- a/pytest_test_groups/__init__.py
+++ b/pytest_test_groups/__init__.py
@@ -20,7 +20,7 @@ def get_file_group(items, group_count, group_id):
     modules_to_items = defaultdict(list)
 
     for item in items:
-        modules_to_items[item.module].append(item)
+        modules_to_items[item.module.__file__].append(item)
 
     sorted_modules_items = sorted(
         modules_to_items.items(),

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -88,7 +88,8 @@ def test_file_group_groups_by_modules():
 
     group = get_file_group(items, 2, 1)
 
-    assert {item.filename for item in group} == {item.filename for item in items if item.module == module1}
+    assert len(group) == 2
+    assert len({item.module for item in group}) == 1
 
 
 def test_file_group__group_evenly():

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -96,7 +96,7 @@ def test_file_group__group_evenly():
     module1 = unique('module1')
     module2 = unique('module2')
     module3 = unique('module3')
-    module4 = unique('module3')
+    module4 = unique('module4')
 
     items = [MockItem(module1) for _ in range(100)]
     items += [MockItem(module2) for _ in range(22)]
@@ -108,17 +108,17 @@ def test_file_group__group_evenly():
     # total of 245 tests between 3 groups. Desired: 81.66 tests in each group.
     # Using greedy algorithm, this means:
     # group1: module1
-    # group2: module3 + module2
-    # group3: module2
+    # group2: module3
+    # group3: module2 + module4
 
     group1 = get_file_group(items, 3, 1)
     assert len(group1) == 100
     assert {item.filename for item in group1} == {item.filename for item in items if item.module == module1}
 
     group2 = get_file_group(items, 3, 2)
-    assert len(group2) == 82
-    assert {item.filename for item in group2} == {item.filename for item in items if item.module in (module2, module3)}
+    assert len(group2) == 60
+    assert {item.filename for item in group2} == {item.filename for item in items if item.module == module3}
 
     group3 = get_file_group(items, 3, 3)
-    assert len(group3) == 25
-    assert {item.filename for item in group3} == {item.filename for item in items if item.module == module4}
+    assert len(group3) == 47
+    assert {item.filename for item in group3} == {item.filename for item in items if item.module in (module4, module2)}

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -121,4 +121,3 @@ def test_file_group__group_evenly():
     group3 = get_file_group(items, 3, 3)
     assert len(group3) == 25
     assert {item.filename for item in group3} == {item.filename for item in items if item.module == module4}
-

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -1,3 +1,4 @@
+import random
 from itertools import chain
 from uuid import uuid4
 
@@ -81,11 +82,43 @@ def test_file_group_that_is_too_low_raises_value_error():
 
 
 def test_file_group_groups_by_modules():
-    group1 = unique('module1')
-    group2 = unique('module2')
-    items = [MockItem(group1), MockItem(group2), MockItem(group2), MockItem(group1)]
+    module1 = unique('module1')
+    module2 = unique('module2')
+    items = [MockItem(module1), MockItem(module2), MockItem(module2), MockItem(module1)]
 
     group = get_file_group(items, 2, 1)
 
-    assert {item.filename for item in group} == {item.filename for item in items if item.module == group1}
+    assert {item.filename for item in group} == {item.filename for item in items if item.module == module1}
+
+
+def test_file_group__group_evenly():
+    module1 = unique('module1')
+    module2 = unique('module2')
+    module3 = unique('module3')
+    module4 = unique('module3')
+
+    items = [MockItem(module1) for _ in range(100)]
+    items += [MockItem(module2) for _ in range(22)]
+    items += [MockItem(module3) for _ in range(60)]
+    items += [MockItem(module4) for _ in range(25)]
+
+    random.shuffle(items)
+
+    # total of 245 tests between 3 groups. Desired: 81.66 tests in each group.
+    # Using greedy algorithm, this means:
+    # group1: module1
+    # group2: module3 + module2
+    # group3: module2
+
+    group1 = get_file_group(items, 3, 1)
+    assert len(group1) == 100
+    assert {item.filename for item in group1} == {item.filename for item in items if item.module == module1}
+
+    group2 = get_file_group(items, 3, 2)
+    assert len(group2) == 82
+    assert {item.filename for item in group2} == {item.filename for item in items if item.module in (module2, module3)}
+
+    group3 = get_file_group(items, 3, 3)
+    assert len(group3) == 25
+    assert {item.filename for item in group3} == {item.filename for item in items if item.module == module4}
 

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -1,8 +1,19 @@
 from itertools import chain
+from uuid import uuid4
 
 import pytest
 
-from pytest_test_groups import get_group
+from pytest_test_groups import get_group, get_file_group
+
+
+def unique(suffix):
+    return uuid4().hex[:6] + suffix
+
+
+class MockItem:
+    def __init__(self, module):
+        self.module = str(module)
+        self.filename = unique('.py')
 
 
 def test_group_is_the_proper_size():
@@ -35,3 +46,46 @@ def test_group_that_is_too_low_raises_value_error():
     with pytest.raises(ValueError):
         # When group_count=4, group_id=0 is out of bounds
         get_group(items, 4, 0)
+
+
+def test_file_group_is_the_proper_size():
+    items = [MockItem(i) for i in range(32)]
+    group = get_file_group(items, 8, 1)
+
+    assert len(group) == 4
+
+
+def test_all_file_groups_together_form_original_set_of_tests():
+    group_count = 8
+    for item_size in range(group_count, 32):
+        items = [MockItem(i) for i in range(item_size)]
+        groups = [get_file_group(items, group_count, i) for i in range(1, group_count + 1)]
+        combined = set(chain.from_iterable(groups))
+        assert combined == set(items)
+
+
+def test_file_group_that_is_too_high_raises_value_error():
+    items = [MockItem(i) for i in range(32)]
+
+    with pytest.raises(ValueError):
+        # When group_count=4, group_id=5 is out of bounds
+        get_file_group(items, 4, 5)
+
+
+def test_file_group_that_is_too_low_raises_value_error():
+    items = [MockItem(i) for i in range(32)]
+
+    with pytest.raises(ValueError):
+        # When group_count=4, group_id=0 is out of bounds
+        get_file_group(items, 4, 0)
+
+
+def test_file_group_groups_by_modules():
+    group1 = unique('module1')
+    group2 = unique('module2')
+    items = [MockItem(group1), MockItem(group2), MockItem(group2), MockItem(group1)]
+
+    group = get_file_group(items, 2, 1)
+
+    assert {item.filename for item in group} == {item.filename for item in items if item.module == group1}
+

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -86,8 +86,7 @@ def test_group_by_files(testdir):
 
     result = testdir.inline_run('--test-group-count', '2',
                                 '--test-group', '1',
-                                '--test-group-by-files',
-    )
+                                '--test-group-by-files')
     group_1 = [x.item.name for x in result.calls if x._name == 'pytest_runtest_call']
     result.assertoutcome(passed=2)
 
@@ -95,8 +94,7 @@ def test_group_by_files(testdir):
 
     result = testdir.inline_run('--test-group-count', '2',
                                 '--test-group', '2',
-                                '--test-group-by-files',
-    )
+                                '--test-group-by-files')
     group_2 = [x.item.name for x in result.calls if x._name == 'pytest_runtest_call']
     result.assertoutcome(passed=3)
     assert set(group_2) == {'test_c', 'test_d', 'test_e'}

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -77,9 +77,9 @@ def test_group_by_files(testdir):
     testdir.makepyfile(test_file_1="""
         def test_a(): pass
         def test_b(): pass
+        def test_c(): pass
     """,
                        test_file_2="""
-        def test_c(): pass
         def test_d(): pass
         def test_e(): pass
      """)
@@ -88,16 +88,16 @@ def test_group_by_files(testdir):
                                 '--test-group', '1',
                                 '--test-group-by-files')
     group_1 = [x.item.name for x in result.calls if x._name == 'pytest_runtest_call']
-    result.assertoutcome(passed=2)
+    result.assertoutcome(passed=3)
 
-    assert set(group_1) == {'test_a', 'test_b'}
+    assert set(group_1) == {'test_a', 'test_b', 'test_c'}
 
     result = testdir.inline_run('--test-group-count', '2',
                                 '--test-group', '2',
                                 '--test-group-by-files')
     group_2 = [x.item.name for x in result.calls if x._name == 'pytest_runtest_call']
-    result.assertoutcome(passed=3)
-    assert set(group_2) == {'test_c', 'test_d', 'test_e'}
+    result.assertoutcome(passed=2)
+    assert set(group_2) == {'test_d', 'test_e'}
 
 
 def test_group_by_files__more_groups_than_files(testdir):
@@ -117,9 +117,9 @@ def test_group_by_files__more_groups_than_files(testdir):
         '--test-group-by-files',
     )
     group_1 = set(x.item.name for x in result.calls if x._name == 'pytest_runtest_call')
-    result.assertoutcome(passed=2)
+    result.assertoutcome(passed=3)
 
-    assert group_1 == {'test_a', 'test_b'}
+    assert group_1 == {'test_c', 'test_d', 'test_e'}
 
     result = testdir.inline_run(
         '--test-group-count', '3',
@@ -128,9 +128,9 @@ def test_group_by_files__more_groups_than_files(testdir):
     )
 
     group_2 = set(x.item.name for x in result.calls if x._name == 'pytest_runtest_call')
-    result.assertoutcome(passed=3)
+    result.assertoutcome(passed=2)
 
-    assert group_2 == {'test_c', 'test_d', 'test_e'}
+    assert group_2 == {'test_a', 'test_b'}
 
     result = testdir.inline_run(
         '--test-group-count', '3',


### PR DESCRIPTION
Thanks for this plugin! We are using it and it helped lowering our pipeline running times from ~60m to ~7m.

However, I found out that failures of unittets tend to be across a small number of files. Since unitests of the same file are devided between multiple (usually all) groups, multiple groups are failing due to a bug that stems in the same area.

This PR adds an option to split by files rather than by items, making the investigation of failures much easier.

Couple of notes, as I'm a bit afraid this PR might not be in the spirit of this project:

1. If the number of files is smaller than total groups some groups will run no tests.
2. Some jobs might take longer than others, as there is no way to guarantee tests will be equally divided between jobs. The division is done using a greedy algorithm which tries to split the tests so each job runs about the same number of tests, but in extreme cases some jobs will work much harder than others (e.g.: only two test files need to run: file1 with 1000 tests, file2 with 2 tests).

Thank you again!